### PR TITLE
コメント作成、一覧機能実装

### DIFF
--- a/public/thread.php
+++ b/public/thread.php
@@ -61,9 +61,13 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             redirect_with_errors('thread.php?id=' . $thread_id, 'comment', $errors, $_POST);
         }
 
-        create_comment($pdo, $thread_id, (int)$_SESSION['user_id'], $content);
-        set_flash_message('success', 'comment', 'created');
-        redirect('thread.php?id=' . $thread_id);
+        if (create_comment($pdo, $thread_id, (int)$_SESSION['user_id'], $content)) {
+            set_flash_message('success', 'comment', 'created');
+            redirect('thread.php?id=' . $thread_id);
+        } else {
+            set_flash_message('error', 'comment', 'create_failed');
+            redirect_with_errors('thread.php?id=' . $thread_id, 'comment', $errors, $_POST);
+        }
     }
 
     if (!is_thread_owner($thread['user_id'], (int)$_SESSION['user_id'])) {

--- a/public/thread.php
+++ b/public/thread.php
@@ -29,6 +29,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         set_flash_message('error', 'thread', 'not_found');
         redirect('index.php');
     }
+    $comments = fetch_comments_by_thread_id($pdo, $thread_id);
 }
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -51,6 +52,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         set_flash_message('error', 'thread', 'not_found');
         redirect('index.php');
     }
+
     if (isset($_POST['comment'])) {
         $content = trim($_POST['content']);
         $errors['content'] = validate_comment($content);
@@ -116,6 +118,28 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 </div>
             <?php endif; ?>
         </div>
+
+        <div class="comments">
+            <h2>コメント一覧</h2>
+            <?php if (!empty($comments)): ?>
+                <?php foreach ($comments as $comment): ?>
+                    <div class="comment">
+                        <span class="comment-author">
+                            <?= htmlspecialchars($comment['last_name'] . ' ' . $comment['first_name']) ?>
+                        </span>
+                        <span class="comment-date">
+                            <?= htmlspecialchars((new DateTime($comment['created_at']))->format('Y/m/d H:i')) ?>
+                        </span>
+                        <div class="comment-content">
+                            <?= nl2br(htmlspecialchars($comment['content'])) ?>
+                        </div>
+                    </div>
+                <?php endforeach; ?>
+            <?php else: ?>
+                <p>コメントはまだありません。</p>
+            <?php endif; ?>
+        </div>
+
         <?php if (isset($_SESSION['user_id'])): ?>
             <div class="comment-form">
                 <h2>コメントを投稿する</h2>

--- a/public/thread.php
+++ b/public/thread.php
@@ -7,8 +7,15 @@ require_once __DIR__ . '/../src/lib/flash_message.php';
 require_once __DIR__ . '/../src/lib/auth.php';
 require_once __DIR__ . '/../src/config/database.php';
 require_once __DIR__ . '/../src/models/thread.php';
+require_once __DIR__ . '/../src/models/comment.php';
+require_once __DIR__ . '/../src/validations/comment.php';
 
 $pdo = getPDO();
+$errors = get_form_errors('comment');
+$old = get_form_old('comment');
+
+clear_form_errors('comment');
+clear_form_old('comment');
 
 if ($_SERVER['REQUEST_METHOD'] === 'GET') {
     $thread_id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT) ?? null;
@@ -43,6 +50,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (!$thread) {
         set_flash_message('error', 'thread', 'not_found');
         redirect('index.php');
+    }
+    if (isset($_POST['comment'])) {
+        $content = trim($_POST['content']);
+        $errors['content'] = validate_comment($content);
+
+        if (array_filter($errors)) {
+            redirect_with_errors('thread.php?id=' . $thread_id, 'comment', $errors, $_POST);
+        }
+
+        create_comment($pdo, $thread_id, (int)$_SESSION['user_id'], $content);
+        set_flash_message('success', 'comment', 'created');
+        redirect('thread.php?id=' . $thread_id);
     }
 
     if (!is_thread_owner($thread['user_id'], (int)$_SESSION['user_id'])) {
@@ -97,6 +116,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 </div>
             <?php endif; ?>
         </div>
+        <?php if (isset($_SESSION['user_id'])): ?>
+            <div class="comment-form">
+                <h2>コメントを投稿する</h2>
+                <form action="thread.php?id=<?= $thread['id'] ?>" method="post">
+                    <input type="hidden" name="id" value="<?= htmlspecialchars($thread['id']) ?>">
+                    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(generate_csrf_token()) ?>">
+                    <textarea name="content" rows="3" cols="50" ><?= htmlspecialchars($old['content'] ?? '') ?></textarea>
+                    <?php $name = 'content'; include __DIR__ . '/../src/partials/error_message.php'; ?>
+                    <br>
+                    <button type="submit" name="comment">投稿</button>
+                </form>
+            </div>
+        <?php endif; ?>
     </div>
 </body>
 </html>

--- a/src/config/message.php
+++ b/src/config/message.php
@@ -23,6 +23,7 @@ const MESSAGES = [
       'required' => 'を入力してください。',
       'select' => 'を選択してください。',
       'max_length' => 'は{max_length}文字以内で入力してください。',
+      'min_length' => 'は{min_length}文字以上で入力してください。',
     ],
     'auth' => [
       'require_login' => 'ログインしてください。',

--- a/src/config/message.php
+++ b/src/config/message.php
@@ -17,6 +17,9 @@ const MESSAGES = [
       'updated' => 'アカウントを更新しました。',
       'deleted' => 'アカウントを削除しました。',
     ],
+    'comment' => [
+      'created' => 'コメントを投稿しました。',
+    ],
   ],
   'error' => [
     'common' => [

--- a/src/models/comment.php
+++ b/src/models/comment.php
@@ -1,0 +1,8 @@
+<?php
+
+
+function create_comment($pdo, $thread_id, $user_id, $content) {
+    $sql = "INSERT INTO comments (thread_id, user_id, content, created_at, updated_at) VALUES (?, ?, ?, NOW(), NOW())";
+    $stmt = $pdo->prepare($sql);
+    return $stmt->execute([$thread_id, $user_id, $content]);
+}

--- a/src/models/comment.php
+++ b/src/models/comment.php
@@ -1,5 +1,17 @@
 <?php
 
+function fetch_comments_by_thread_id($pdo, $thread_id) {
+    $sql = <<<SQL
+        SELECT comments.*, users.first_name, users.last_name
+        FROM comments
+        JOIN users ON comments.user_id = users.id
+        WHERE comments.thread_id = ?
+        ORDER BY comments.created_at ASC
+    SQL;
+    $stmt = $pdo->prepare($sql);
+    $stmt->execute([$thread_id]);
+    return $stmt->fetchAll();
+}
 
 function create_comment($pdo, $thread_id, $user_id, $content) {
     $sql = "INSERT INTO comments (thread_id, user_id, content, created_at, updated_at) VALUES (?, ?, ?, NOW(), NOW())";

--- a/src/validations/comment.php
+++ b/src/validations/comment.php
@@ -1,0 +1,15 @@
+<?php
+
+require_once __DIR__ . '/common.php';
+
+function validate_comment($content) {
+  if ($error = validate_min_length($content, 'コメント', 1)) {
+    return $error;
+  }
+
+  if ($error = validate_max_length($content, 'コメント', 500)) {
+    return $error;
+  }
+
+  return null;
+}

--- a/src/validations/common.php
+++ b/src/validations/common.php
@@ -14,6 +14,13 @@ function validate_select($value, $field_name) {
     return null;
 }
 
+function validate_min_length($value, $field_name, $min_length) {
+    if (mb_strlen($value) < $min_length) {
+        return $field_name . str_replace('{min_length}', $min_length, MESSAGES['error']['common']['min_length']);
+    }
+    return null;
+}
+
 function validate_max_length($value, $field_name, $max_length) {
     if (mb_strlen($value) > $max_length) {
         return $field_name . str_replace('{max_length}', $max_length, MESSAGES['error']['common']['max_length']);


### PR DESCRIPTION
## 概要

PHPフルスクラッチでコメント作成、一覧機能実装

## 関連するissue番号

- #35 

## 行ったこと

- commentsテーブル作成
- スレッド詳細にコメントフォーム作成
- コメントを作成する処理作成
- スレッド詳細でスレッドに紐づくコメント一覧を取得する処理作成
- 共通の最小文字数のバリデーション関数を作成

## 動作確認

## その他


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to view and post comments on thread pages.
  - Logged-in users can submit comments with validation and error feedback.
  - Success and error messages are displayed for comment actions.

- **Bug Fixes**
  - Improved input validation for comment length to ensure minimum and maximum limits.

- **Documentation**
  - Updated message configurations to include new comment-related messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->