### PR TITLE
コメント削除機能を実装

### DIFF
--- a/public/thread.php
+++ b/public/thread.php
@@ -70,6 +70,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
     }
 
+    if (isset($_POST['delete_comment']) && isset($_POST['delete_comment_id'])) {
+        $comment_id = (int)$_POST['delete_comment_id'];
+
+        if (delete_comment($pdo, $comment_id, (int)$_SESSION['user_id'])) {
+            set_flash_message('success', 'comment', 'deleted');
+        } else {
+            set_flash_message('error', 'comment', 'delete_failed');
+        }
+        redirect('thread.php?id=' . $thread_id);
+    }
+
     if (!is_thread_owner($thread['user_id'], (int)$_SESSION['user_id'])) {
         set_flash_message('error', 'thread', 'not_owner');
         redirect('index.php');
@@ -137,6 +148,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         <div class="comment-content">
                             <?= nl2br(htmlspecialchars($comment['content'])) ?>
                         </div>
+                        <?php if (isset($_SESSION['user_id']) && (int)$_SESSION['user_id'] === (int)$comment['user_id']): ?>
+                            <form action="thread.php?id=<?= $thread['id'] ?>" method="post" style="display:inline;">
+                                <input type="hidden" name="id" value="<?= htmlspecialchars($thread['id']) ?>">
+                                <input type="hidden" name="delete_comment_id" value="<?= htmlspecialchars($comment['id']) ?>">
+                                <input type="hidden" name="csrf_token" value="<?= htmlspecialchars(generate_csrf_token()) ?>">
+                                <button type="submit" name="delete_comment" onclick="return confirm('本当に削除しますか？')">削除</button>
+                            </form>
+                        <?php endif; ?>
                     </div>
                 <?php endforeach; ?>
             <?php else: ?>

--- a/public/thread.php
+++ b/public/thread.php
@@ -72,6 +72,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     if (isset($_POST['delete_comment']) && isset($_POST['delete_comment_id'])) {
         $comment_id = (int)$_POST['delete_comment_id'];
+        if (!validate_comment_exists($pdo, $thread_id, $comment_id)) {
+            set_flash_message('error', 'comment', 'not_found');
+            redirect('thread.php?id=' . $thread_id);
+        }
 
         if (delete_comment($pdo, $comment_id, (int)$_SESSION['user_id'])) {
             set_flash_message('success', 'comment', 'deleted');

--- a/src/config/message.php
+++ b/src/config/message.php
@@ -66,6 +66,7 @@ const MESSAGES = [
     ],
     'comment' => [
       'delete_failed' => 'コメントの削除に失敗しました。',
+      'not_found' => 'コメントが見つかりません。',
     ],
   ]
 ];

--- a/src/config/message.php
+++ b/src/config/message.php
@@ -19,6 +19,7 @@ const MESSAGES = [
     ],
     'comment' => [
       'created' => 'コメントを投稿しました。',
+      'deleted' => 'コメントを削除しました。',
     ],
   ],
   'error' => [
@@ -62,6 +63,9 @@ const MESSAGES = [
     ],
     'database' => [
       'connection_error' => 'データベース接続エラーが発生しました。管理者にお問い合わせください。',
+    ],
+    'comment' => [
+      'delete_failed' => 'コメントの削除に失敗しました。',
     ],
   ]
 ];

--- a/src/models/comment.php
+++ b/src/models/comment.php
@@ -18,3 +18,8 @@ function create_comment($pdo, $thread_id, $user_id, $content) {
     $stmt = $pdo->prepare($sql);
     return $stmt->execute([$thread_id, $user_id, $content]);
 }
+
+function delete_comment($pdo, $comment_id, $user_id) {
+    $stmt = $pdo->prepare('DELETE FROM comments WHERE id = ? AND user_id = ?');
+    return $stmt->execute([$comment_id, $user_id]);
+}

--- a/src/validations/comment.php
+++ b/src/validations/comment.php
@@ -13,3 +13,10 @@ function validate_comment($content) {
 
   return null;
 }
+
+function validate_comment_exists($pdo, $thread_id, $comment_id) {
+  $sql = "SELECT COUNT(*) FROM comments WHERE id = ? AND thread_id = ?";
+  $stmt = $pdo->prepare($sql);
+  $stmt->execute([$comment_id, $thread_id]);
+  return $stmt->fetchColumn() > 0;
+}


### PR DESCRIPTION
## 概要

PHPフルスクラッチでコメント削除機能を実装する

## 関連するissue番号

- #36 

## 行ったこと

- コメント削除ボタン作成
- 自分のコメントを削除する処理作成

## 動作確認

## その他


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Users can now delete their own comments from threads, with a confirmation prompt and CSRF protection.
- **User Messages**
  - Added new notifications for successful comment deletion and for deletion failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->