### PR TITLE
スレッド閲覧履歴保存、一覧機能実装

### DIFF
--- a/public/thread.php
+++ b/public/thread.php
@@ -8,6 +8,7 @@ require_once __DIR__ . '/../src/lib/auth.php';
 require_once __DIR__ . '/../src/config/database.php';
 require_once __DIR__ . '/../src/models/thread.php';
 require_once __DIR__ . '/../src/models/comment.php';
+require_once __DIR__ . '/../src/models/thread_view.php';
 require_once __DIR__ . '/../src/validations/comment.php';
 
 $pdo = getPDO();
@@ -30,6 +31,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET') {
         redirect('index.php');
     }
     $comments = fetch_comments_by_thread_id($pdo, $thread_id);
+
+    if (isset($_SESSION['user_id'])) {
+        save_thread_view($pdo, (int)$_SESSION['user_id'], $thread_id);
+    }
 }
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {

--- a/public/thread_views.php
+++ b/public/thread_views.php
@@ -1,0 +1,50 @@
+<?php
+
+session_start();
+
+require_once __DIR__ . '/../src/lib/auth.php';
+require_once __DIR__ . '/../src/lib/csrf.php';
+require_once __DIR__ . '/../src/config/database.php';
+require_once __DIR__ . '/../src/models/thread_view.php';
+
+require_login();
+
+$pdo = getPDO();
+$views = fetch_thread_views($pdo, $_SESSION['user_id'], 20);
+
+?>
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>スレッド閲覧履歴</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <?php include __DIR__ . '/../src/partials/header.php'; ?>
+  <?php include __DIR__ . '/../src/partials/flash_message.php'; ?>
+  <?php include __DIR__ . '/../src/partials/sidebar.php'; ?>
+
+  <h1>最近見たスレッド</h1>
+
+  <div class="threads">
+    <?php if (empty($views)): ?>
+      <p>スレッドはありません</p>
+    <?php else: ?>
+      <?php foreach ($views as $view): ?>
+        <a href="/thread.php?id=<?= $view['id'] ?>" class="thread-link">
+          <div class="thread">
+            <div class="thread-header">
+              <span class="thread-date"><?= htmlspecialchars((new DateTime($view['viewed_at']))->format('Y/m/d H:i')) ?></span>
+            </div>
+            <div class="thread-title"><?= htmlspecialchars($view['title']) ?></div>
+          </div>
+        </a>
+      <?php endforeach; ?>
+    <?php endif; ?>
+  </div>
+</body>
+</html>
+

--- a/src/models/thread_view.php
+++ b/src/models/thread_view.php
@@ -23,8 +23,8 @@ function save_thread_view($pdo, $user_id, $thread_id) {
     $stmt->execute([$user_id, $thread_id, $now_str]);
 }
 
-function fetch_thread_views($pdo, $user_id, $limit = 10) {
-    $stmt = $pdo->prepare("SELECT t.id, t.title, v.viewed_at FROM thread_views v JOIN threads t ON v.thread_id = t.id WHERE v.user_id = ? ORDER BY v.viewed_at DESC LIMIT $limit");
+function fetch_thread_views($pdo, $user_id) {
+    $stmt = $pdo->prepare("SELECT t.id, t.title, v.viewed_at FROM thread_views v JOIN threads t ON v.thread_id = t.id WHERE v.user_id = ? ORDER BY v.viewed_at DESC");
     $stmt->execute([$user_id]);
     return $stmt->fetchAll();
 } 

--- a/src/models/thread_view.php
+++ b/src/models/thread_view.php
@@ -1,0 +1,30 @@
+<?php
+
+function was_recently_viewed($pdo, $user_id, $thread_id, $interval_seconds = 300) {
+    $stmt = $pdo->prepare('SELECT viewed_at FROM thread_views WHERE user_id = ? AND thread_id = ?');
+    $stmt->execute([$user_id, $thread_id]);
+    $last_view = $stmt->fetchColumn();
+    if ($last_view) {
+        $last_time = strtotime($last_view);
+        $now = time();
+        if ($now - $last_time < $interval_seconds) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function save_thread_view($pdo, $user_id, $thread_id) {
+    if (was_recently_viewed($pdo, $user_id, $thread_id, 300)) {
+        return;
+    }
+    $now_str = date('Y-m-d H:i:s');
+    $stmt = $pdo->prepare('INSERT INTO thread_views (user_id, thread_id, viewed_at) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE viewed_at = VALUES(viewed_at)');
+    $stmt->execute([$user_id, $thread_id, $now_str]);
+}
+
+function fetch_thread_views($pdo, $user_id, $limit = 10) {
+    $stmt = $pdo->prepare("SELECT t.id, t.title, v.viewed_at FROM thread_views v JOIN threads t ON v.thread_id = t.id WHERE v.user_id = ? ORDER BY v.viewed_at DESC LIMIT $limit");
+    $stmt->execute([$user_id]);
+    return $stmt->fetchAll();
+} 

--- a/src/partials/sidebar.php
+++ b/src/partials/sidebar.php
@@ -7,6 +7,11 @@
         </a>
       </li>
       <li class="nav-item">
+        <a class="nav-link" href="/thread_views.php">
+          <i class="fas fa-history"></i> 閲覧履歴
+        </a>
+      </li>
+      <li class="nav-item">
         <a class="nav-link text-danger" href="/withdraw.php">
           <i class="fas fa-user-times"></i> 退会
         </a>


### PR DESCRIPTION
## 概要

## 関連するissue番号

- #

## 行ったこと

- スレッド詳細にアクセスした時にログインユーザーのみスレッド閲覧履歴を保存する処理を作成
- スレッド閲覧履歴一覧ページを作成
- スレッド閲覧履歴取得処理作成

## 動作確認

http://localhost:8080/thread_views.php

## その他


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a browsing history page where users can view their recently viewed threads.
  - Added a new sidebar menu item labeled "閲覧履歴" (Browsing History) for quick access to recently viewed threads.
- **User Experience**
  - Thread views are now automatically recorded when logged-in users access threads, allowing for accurate browsing history tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->